### PR TITLE
fix the positioning issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/smithlab_cpp"]
 	path = src/smithlab_cpp
-	url = https://github.com/smithlabcode/smithlab_cpp
+	url = https://github.com/smithlabcode/smithlab_cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/smithlab_cpp"]
 	path = src/smithlab_cpp
-	url = https://github.com/smithlabcode/smithlab_cpp.git
+	url = https://github.com/smithlabcode/smithlab_cpp

--- a/src/radmeth/combine_pvals.cpp
+++ b/src/radmeth/combine_pvals.cpp
@@ -150,7 +150,7 @@ ProximalLoci::get(vector<PvalLocus> &neighbors) {
 
     do {
       --up_pos;
-      size_t up_dist = cur_pos->pos - (up_pos->pos + 1);
+      size_t up_dist = cur_pos->pos - (up_pos->pos);
 
       if(up_dist <= max_distance_) {
           neighbors.push_back(*up_pos);
@@ -168,7 +168,7 @@ ProximalLoci::get(vector<PvalLocus> &neighbors) {
 
     do {
       ++down_pos;
-      size_t down_dist = down_pos->pos - (cur_pos->pos + 1);
+      size_t down_dist = down_pos->pos - cur_pos->pos;
 
       if (down_dist <= max_distance_) {
           neighbors.push_back(*down_pos);
@@ -193,7 +193,7 @@ DistanceCorrelation::bin(const vector<PvalLocus> &loci) {
     bool too_far = false;
 
     while (forward_it != loci.end() && !too_far) {
-      const size_t dist = forward_it->pos - (it->pos + 1);
+      const size_t dist = forward_it->pos - it->pos;
       const size_t bin = bin_for_dist_.which_bin(dist);
 
       //check if the appropriate bin exists
@@ -262,7 +262,7 @@ distance_corr_matrix(BinForDistance bin_for_dist,
 
   for (size_t row = 0; row < num_neighbors; ++row) {
     corr_matrix[row][row] = 1.0;
-    const size_t row_locus = neighbors[row].pos + 1;
+    const size_t row_locus = neighbors[row].pos;
 
     for (size_t col = row + 1; col < num_neighbors; ++col) {
       const size_t col_locus = neighbors[col].pos;

--- a/src/radmeth/radmeth.cpp
+++ b/src/radmeth/radmeth.cpp
@@ -385,12 +385,11 @@ main(int argc, const char **argv) {
           if (0 <= pval && pval <= 1) {
             // locus is on new chrom.
             if (!prev_chrom.empty() && prev_chrom != chrom)
-              chrom_offset += pvals.back().pos;
+		chrom_offset += pvals.back().pos+bin_for_dist.max_dist() + 1;//shift bin_for_dist.max_dist() to this place more readable and more efficient
 
             PvalLocus plocus;
             plocus.raw_pval = pval;
-            plocus.pos = chrom_offset +
-            bin_for_dist.max_dist() + 1 + position;
+            plocus.pos = chrom_offset + position;
 
             pvals.push_back(plocus);
             prev_chrom = chrom;


### PR DESCRIPTION
Hi 

There are some problems in the master branch on how to compute the distance between the two positions of two cpg sites. 

The following is a toy cpg data 

[cpgs_toy1.bed.txt](https://github.com/smithlabcode/methpipe/files/652875/cpgs_toy1.bed.txt)

Please remove the ".txt" extension as the git doesn't allow .bed extension.

The command  radmeth adjust -bins 1:2:1 cpgs_toy1.bed will consider the two cpg sites on chr1 as neighbours and the distance is already 3, which is already more than the maximum distance 2. 

This branch positioning_fix was trying to take care of the corner cases where the distance between neighbouring was computed incorrectly. 

If the distance was understood as the number of nucleotide bases that are between the two positions (like the gap distance), then we have to specify the bin the command as 
radmeth adjust -bins 0:1:1 cpgs_toy1.bed
which is less appealing.
