### PR TITLE
Sam pre release

### DIFF
--- a/src/utils/duplicate-remover.cpp
+++ b/src/utils/duplicate-remover.cpp
@@ -304,7 +304,9 @@ int main(int argc, const char **argv) {
     /****************** COMMAND LINE OPTIONS ********************/
     OptionParser opt_parse(strip_path(argv[0]), "program to remove "
                            "duplicate reads from sorted mapped reads",
-                           "<in-file> <out-file>", 2);
+                           "<in-file>", 1);
+   opt_parse.add_opt("output", 'o', "output file name",
+                     false, outfile);
     opt_parse.add_opt("stats", 'S', "statistics output file", false, statfile);
     opt_parse.add_opt("hist", '\0', "histogram output file for library"
                       " complexity analysis", false, histfile);
@@ -331,14 +333,13 @@ int main(int argc, const char **argv) {
       cerr << opt_parse.option_missing_message() << endl;
       return EXIT_SUCCESS;
     }
-    if (leftover_args.size() != 2) {
+    if (leftover_args.empty()) {
       cerr << opt_parse.help_message() << endl
            << opt_parse.about_message() << endl;
       return EXIT_SUCCESS;
     }
 
     const string infile(leftover_args.front());
-    const string outfile(leftover_args.back());
     /****************** END COMMAND LINE OPTIONS *****************/
 
     srand(the_seed);
@@ -346,6 +347,15 @@ int main(int argc, const char **argv) {
     std::ofstream out(outfile);
     if (!out)
       throw runtime_error("failed to open output file: " + outfile);
+
+    std::ofstream of;
+    if (!outfile.empty()) of.open(outfile.c_str());
+    std::ostream out(outfile.empty() ? cout.rdbuf() : of.rdbuf());
+    if (VERBOSE)
+      cerr << "[input file: " << infile << "]" << endl
+           << "[output file: "
+           << (outfile.empty() ? "stdout" : outfile) << "]" << endl;
+
 
     duplicate_remover(VERBOSE, USE_SEQUENCE, ALL_C, DISABLE_SORT_TEST,
                       infile, statfile, histfile, out);

--- a/src/utils/duplicate-remover.cpp
+++ b/src/utils/duplicate-remover.cpp
@@ -343,7 +343,9 @@ int main(int argc, const char **argv) {
 
     srand(the_seed);
 
-    std::ofstream out(outfile);
+    std::ofstream of;
+    if (outfile!="-") of.open(outfile.c_str());
+    std::ostream out(outfile!="-" ? cout.rdbuf() : of.rdbuf());
     if (!out)
       throw runtime_error("failed to open output file: " + outfile);
 

--- a/src/utils/duplicate-remover.cpp
+++ b/src/utils/duplicate-remover.cpp
@@ -304,9 +304,7 @@ int main(int argc, const char **argv) {
     /****************** COMMAND LINE OPTIONS ********************/
     OptionParser opt_parse(strip_path(argv[0]), "program to remove "
                            "duplicate reads from sorted mapped reads",
-                           "<in-file>", 1);
-   opt_parse.add_opt("output", 'o', "output file name",
-                     false, outfile);
+                           "<in-file> <out-file>", 2);
     opt_parse.add_opt("stats", 'S', "statistics output file", false, statfile);
     opt_parse.add_opt("hist", '\0', "histogram output file for library"
                       " complexity analysis", false, histfile);
@@ -333,13 +331,14 @@ int main(int argc, const char **argv) {
       cerr << opt_parse.option_missing_message() << endl;
       return EXIT_SUCCESS;
     }
-    if (leftover_args.empty()) {
+    if (leftover_args.size() != 2) {
       cerr << opt_parse.help_message() << endl
            << opt_parse.about_message() << endl;
       return EXIT_SUCCESS;
     }
 
     const string infile(leftover_args.front());
+    const string outfile(leftover_args.back());
     /****************** END COMMAND LINE OPTIONS *****************/
 
     srand(the_seed);
@@ -347,15 +346,6 @@ int main(int argc, const char **argv) {
     std::ofstream out(outfile);
     if (!out)
       throw runtime_error("failed to open output file: " + outfile);
-
-    std::ofstream of;
-    if (!outfile.empty()) of.open(outfile.c_str());
-    std::ostream out(outfile.empty() ? cout.rdbuf() : of.rdbuf());
-    if (VERBOSE)
-      cerr << "[input file: " << infile << "]" << endl
-           << "[output file: "
-           << (outfile.empty() ? "stdout" : outfile) << "]" << endl;
-
 
     duplicate_remover(VERBOSE, USE_SEQUENCE, ALL_C, DISABLE_SORT_TEST,
                       infile, statfile, histfile, out);

--- a/src/utils/duplicate-remover.cpp
+++ b/src/utils/duplicate-remover.cpp
@@ -304,7 +304,7 @@ int main(int argc, const char **argv) {
     /****************** COMMAND LINE OPTIONS ********************/
     OptionParser opt_parse(strip_path(argv[0]), "program to remove "
                            "duplicate reads from sorted mapped reads",
-                           "<in-file> <out-file>", 2);
+                           "<in-file> <out-file> (use - for stdout)", 2);
     opt_parse.add_opt("stats", 'S', "statistics output file", false, statfile);
     opt_parse.add_opt("hist", '\0', "histogram output file for library"
                       " complexity analysis", false, histfile);

--- a/src/utils/duplicate-remover.cpp
+++ b/src/utils/duplicate-remover.cpp
@@ -345,7 +345,7 @@ int main(int argc, const char **argv) {
 
     std::ofstream of;
     if (outfile!="-") of.open(outfile.c_str());
-    std::ostream out(outfile!="-" ? cout.rdbuf() : of.rdbuf());
+    std::ostream out(outfile=="-" ? cout.rdbuf() : of.rdbuf());
     if (!out)
       throw runtime_error("failed to open output file: " + outfile);
 


### PR DESCRIPTION
Hi Smith lab,

I've been trying out abismal with your downstream analysis tools, and I found that I always wanted to write to stdout so that I could compress output to bam before writing it to disk. This is possible with all of the tools I've tried except duplicate-remover, so I added the option to specify the output file as ````-```` to send the output to stdout in a similar manner to the other switches in the other tools. I initially changed the output mechanism in line with the other tools but then realised a more minimal edit was probably more appropirate (hence the reverting commits; I was a bit hasty with it). I thought you might be interested so I thought I'd put in a pull request. I added a relevant note in the help message for duplicate-remover.cpp. 

I'd be happy to re-fork the repository and make the edits in a single commit if you wanted to take the edit but keep the commit history a bit cleaner, but I thought I'd open the pull request first so you could see it before doing that, as the code works for my purposes already.

Thanks!